### PR TITLE
feat: 시작화면 뼈대 및 종료 기능 추가

### DIFF
--- a/app/src/main/java/org/se13/SE13Application.java
+++ b/app/src/main/java/org/se13/SE13Application.java
@@ -14,7 +14,7 @@ public class SE13Application extends Application {
 
     @Override
     public void start(Stage stage) throws IOException {
-        FXMLLoader loader = new FXMLLoader(getClass().getResource("test-view.fxml"));
+        FXMLLoader loader = new FXMLLoader(getClass().getResource("StartScreen.fxml"));
         Scene scene = new Scene(loader.load());
 
         stage.setScene(scene);

--- a/app/src/main/java/org/se13/view/StartScreenController.java
+++ b/app/src/main/java/org/se13/view/StartScreenController.java
@@ -1,0 +1,37 @@
+package org.se13.view;
+
+import javafx.fxml.FXML;
+import javafx.scene.control.Button;
+
+public class StartScreenController {
+
+    @FXML
+    private Button startButton;
+    @FXML
+    private Button settingsButton;
+    @FXML
+    private Button scoreButton;
+    @FXML
+    private Button quitButton;
+
+    @FXML
+    private void handleStartButtonAction() {
+        // Playing Tetris logic
+    }
+
+    @FXML
+    private void handleSettingsButtonAction() {
+        // Turn into a setting screen
+    }
+
+    @FXML
+    private void handleScoreButtonAction() {
+        // Turn into a scoreboard screen
+    }
+
+    @FXML
+    private void handleQuitButtonAction() {
+        // Quit the app
+        System.exit(0);
+    }
+}

--- a/app/src/main/resources/org/se13/StartScreen.fxml
+++ b/app/src/main/resources/org/se13/StartScreen.fxml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<?import javafx.scene.control.Button?>
+<?import javafx.scene.layout.VBox?>
+<?import javafx.scene.text.Text?>
+
+<VBox alignment="CENTER" spacing="10.0" stylesheets="@style.css" xmlns:fx="http://javafx.com/fxml/1" fx:controller="org.se13.view.StartScreenController">
+    <Text text="TETRIS" styleClass="gameTitle" />
+    <Button fx:id="startButton" text="START" styleClass="menuButton" onAction="#handleStartButtonAction"/>
+    <Button fx:id="settingsButton" text="SETTINGS" styleClass="menuButton" onAction="#handleSettingsButtonAction"/>
+    <Button fx:id="scoreButton" text="SCORE" styleClass="menuButton" onAction="#handleScoreButtonAction"/>
+    <Button fx:id="quitButton" text="QUIT" styleClass="menuButton" onAction="#handleQuitButtonAction"/>
+</VBox>

--- a/app/src/main/resources/org/se13/style.css
+++ b/app/src/main/resources/org/se13/style.css
@@ -1,0 +1,21 @@
+.root {
+    -fx-background-color: black;
+}
+
+.gameTitle {
+    -fx-font-size: 24px;
+    -fx-fill: white;
+    -fx-font-weight: bold;
+}
+
+.menuButton {
+    -fx-background-color: yellow;
+    -fx-font-weight: bold;
+    -fx-text-fill: black;
+    -fx-padding: 10px;
+    -fx-min-width: 100px;
+}
+
+.menuButton:hover {
+    -fx-background-color: gold;
+}


### PR DESCRIPTION
#9 
Figma에 작업한 대로 시작화면의 뼈대를 만들고 style.css로 StartScreen.fxml 파일 스타일 추가했습니다. 
StartScreenController.java에는 버튼을 눌렀을 때 지정된 Scene으로 이동하도록 로직 추가할 예정이고, 
일단은 마우스로만 작동하는 Quit 버튼을 만들었는데, 이 부분도 추후에 마우스와 키보드 모두 작동하도록 수정하겠습니다.
저희 main인 SE13Application.java는 시작화면이 생겼기 때문에 이 화면으로 시작되도록 변경했습니다.

현재 Scene의 모든 화면 크기를 어떻게 조절하면 좋을지 고민 중입니다. 