### PR TITLE
feat: 세팅화면 뼈대 구성

### DIFF
--- a/app/src/main/java/org/se13/SE13Application.java
+++ b/app/src/main/java/org/se13/SE13Application.java
@@ -14,7 +14,7 @@ public class SE13Application extends Application {
 
     @Override
     public void start(Stage stage) throws IOException {
-        FXMLLoader loader = new FXMLLoader(getClass().getResource("StartScreen.fxml"));
+        FXMLLoader loader = new FXMLLoader(getClass().getResource("SettingsScreen.fxml"));
         Scene scene = new Scene(loader.load());
 
         stage.setScene(scene);

--- a/app/src/main/java/org/se13/SE13Application.java
+++ b/app/src/main/java/org/se13/SE13Application.java
@@ -14,7 +14,7 @@ public class SE13Application extends Application {
 
     @Override
     public void start(Stage stage) throws IOException {
-        FXMLLoader loader = new FXMLLoader(getClass().getResource("test-view.fxml"));
+        FXMLLoader loader = new FXMLLoader(getClass().getResource("StartScreen.fxml"));
         Scene scene = new Scene(loader.load());
 
         stage.setScene(scene);

--- a/app/src/main/java/org/se13/view/SettingsScreenController.java
+++ b/app/src/main/java/org/se13/view/SettingsScreenController.java
@@ -1,0 +1,36 @@
+package org.se13.view;
+
+import javafx.fxml.FXML;
+import javafx.scene.control.ChoiceBox;
+import javafx.scene.control.ToggleButton;
+
+public class SettingsScreenController {
+
+    @FXML
+    private ChoiceBox<String> screenSizeChoiceBox;
+    @FXML
+    private ToggleButton colorBlindModeToggle;
+
+    @FXML
+    private void initialize() {
+        // Add options in ChoiceBox for the choice among scene size
+        // By selected scene size, the function will implement logic.
+
+        // implement color blind mode
+    }
+
+    @FXML
+    private void handleBackButtonAction() {
+        // Turn into last scene
+    }
+
+    @FXML
+    private void handleSaveButtonAction() {
+        // Saving personal settings
+    }
+
+    @FXML
+    private void handleColorBlindModeToggleAction() {
+        // implement personal color blind mode settings
+    }
+}

--- a/app/src/main/java/org/se13/view/StartScreenController.java
+++ b/app/src/main/java/org/se13/view/StartScreenController.java
@@ -1,0 +1,37 @@
+package org.se13.view;
+
+import javafx.fxml.FXML;
+import javafx.scene.control.Button;
+
+public class StartScreenController {
+
+    @FXML
+    private Button startButton;
+    @FXML
+    private Button settingsButton;
+    @FXML
+    private Button scoreButton;
+    @FXML
+    private Button quitButton;
+
+    @FXML
+    private void handleStartButtonAction() {
+        // Playing Tetris logic
+    }
+
+    @FXML
+    private void handleSettingsButtonAction() {
+        // Turn into a setting screen
+    }
+
+    @FXML
+    private void handleScoreButtonAction() {
+        // Turn into a scoreboard screen
+    }
+
+    @FXML
+    private void handleQuitButtonAction() {
+        // Quit the app
+        System.exit(0);
+    }
+}

--- a/app/src/main/resources/org/se13/SettingsScreen.fxml
+++ b/app/src/main/resources/org/se13/SettingsScreen.fxml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<?import javafx.scene.control.*?>
+<?import javafx.scene.layout.*?>
+<?import javafx.scene.text.*?>
+
+<VBox fx:id="settingsContainer"
+      alignment="CENTER"
+      spacing="20.0"
+      stylesheets="@style.css"
+      xmlns="http://javafx.com/javafx/17.0.2-ea"
+      xmlns:fx="http://javafx.com/fxml/1"
+      fx:controller="org.se13.view.SettingsScreenController">
+    <Text styleClass="settingsTitle" text="SETTINGS"/>
+
+    <HBox alignment="CENTER" spacing="10">
+        <Label styleClass="settingsLabel" text="Scene Size:" textFill="WHITE"/>
+        <ChoiceBox fx:id="screenSizeChoiceBox" styleClass="choiceBox"/>
+    </HBox>
+
+    <Button styleClass="menuButton" text="Key setting"/>
+
+    <ToggleButton fx:id="colorBlindModeToggle" selected="false" styleClass="menuButton" text="색맹모드 OFF"/>
+
+    <HBox spacing="20">
+        <Button styleClass="menuButton" text="초기화"/>
+        <Button styleClass="menuButton" text="저장"/>
+    </HBox>
+
+    <HBox spacing="20">
+        <Button onAction="#handleBackButtonAction" styleClass="menuButton" text="←"/>
+        <Button styleClass="menuButton" text="스크린모드 설정"/>
+    </HBox>
+</VBox>

--- a/app/src/main/resources/org/se13/StartScreen.fxml
+++ b/app/src/main/resources/org/se13/StartScreen.fxml
@@ -4,8 +4,12 @@
 <?import javafx.scene.layout.VBox?>
 <?import javafx.scene.text.Text?>
 
-<VBox alignment="CENTER" spacing="10.0" stylesheets="@style.css" xmlns:fx="http://javafx.com/fxml/1" fx:controller="org.se13.view.StartScreenController">
-    <Text text="TETRIS" styleClass="gameTitle" />
+<VBox alignment="CENTER"
+      spacing="10.0"
+      stylesheets="@style.css"
+      xmlns:fx="http://javafx.com/fxml/1"
+      fx:controller="org.se13.view.StartScreenController">
+    <Text text="TETRIS" styleClass="gameTitle"/>
     <Button fx:id="startButton" text="START" styleClass="menuButton" onAction="#handleStartButtonAction"/>
     <Button fx:id="settingsButton" text="SETTINGS" styleClass="menuButton" onAction="#handleSettingsButtonAction"/>
     <Button fx:id="scoreButton" text="SCORE" styleClass="menuButton" onAction="#handleScoreButtonAction"/>

--- a/app/src/main/resources/org/se13/StartScreen.fxml
+++ b/app/src/main/resources/org/se13/StartScreen.fxml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<?import javafx.scene.control.Button?>
+<?import javafx.scene.layout.VBox?>
+<?import javafx.scene.text.Text?>
+
+<VBox alignment="CENTER" spacing="10.0" stylesheets="@style.css" xmlns:fx="http://javafx.com/fxml/1" fx:controller="org.se13.view.StartScreenController">
+    <Text text="TETRIS" styleClass="gameTitle" />
+    <Button fx:id="startButton" text="START" styleClass="menuButton" onAction="#handleStartButtonAction"/>
+    <Button fx:id="settingsButton" text="SETTINGS" styleClass="menuButton" onAction="#handleSettingsButtonAction"/>
+    <Button fx:id="scoreButton" text="SCORE" styleClass="menuButton" onAction="#handleScoreButtonAction"/>
+    <Button fx:id="quitButton" text="QUIT" styleClass="menuButton" onAction="#handleQuitButtonAction"/>
+</VBox>

--- a/app/src/main/resources/org/se13/style.css
+++ b/app/src/main/resources/org/se13/style.css
@@ -19,3 +19,9 @@
 .menuButton:hover {
     -fx-background-color: gold;
 }
+
+.settingsTitle {
+    -fx-font-size: 24px;
+    -fx-fill: white;
+    -fx-font-weight: bold;
+}

--- a/app/src/main/resources/org/se13/style.css
+++ b/app/src/main/resources/org/se13/style.css
@@ -1,0 +1,21 @@
+.root {
+    -fx-background-color: black;
+}
+
+.gameTitle {
+    -fx-font-size: 24px;
+    -fx-fill: white;
+    -fx-font-weight: bold;
+}
+
+.menuButton {
+    -fx-background-color: yellow;
+    -fx-font-weight: bold;
+    -fx-text-fill: black;
+    -fx-padding: 10px;
+    -fx-min-width: 100px;
+}
+
+.menuButton:hover {
+    -fx-background-color: gold;
+}


### PR DESCRIPTION
#9 
Figma에 작성한 세팅화면에서 scene 화면을 결정하는 표현을 toggle이 아닌 choiceBox을 사용했습니다. 최소 3가지 크기 옵션을 갖고 있는데, 추후에 옵션 개수가 늘어나면 계속 toggle 버튼을 늘리는 것은 비효율적이라고 생각해서 choiceBox를 사용했습니다. 나머지는 Figma에 올려둔 것과 같은 상태입니다.

로직 자체는 아직 구현이 되지 않은 상태여서 추후에 로직을 추가할 예정입니다.

자세한 css도 추후에 구현하겠습니다.

> 경님이 알려주신 Scene Builder 사용해보니 너무 만족스럽습니다