### PR TITLE
화면 이동 시 파라미터들을 전달할 수 있는 navigate 함수 구현

### DIFF
--- a/app/src/main/java/org/se13/NavGraph.java
+++ b/app/src/main/java/org/se13/NavGraph.java
@@ -2,9 +2,13 @@ package org.se13;
 
 import org.se13.view.nav.Screen;
 
+import java.util.function.Consumer;
+
 public interface NavGraph {
 
     void navigate(Screen screen);
+
+    <T> void navigate(Screen screen, Consumer<T> consumer);
 
     void popBackStack();
 }

--- a/app/src/main/java/org/se13/SE13Application.java
+++ b/app/src/main/java/org/se13/SE13Application.java
@@ -14,7 +14,7 @@ public class SE13Application extends Application {
     }
 
     @Override
-    public void start(Stage stage) throws IOException {
+    public void start(Stage stage) {
         navController = new StackNavGraph(stage);
         navController.navigate(Screen.START);
     }

--- a/app/src/main/java/org/se13/StackNavGraph.java
+++ b/app/src/main/java/org/se13/StackNavGraph.java
@@ -7,6 +7,7 @@ import org.se13.view.nav.Screen;
 
 import java.io.IOException;
 import java.util.Stack;
+import java.util.function.Consumer;
 
 public class StackNavGraph implements NavGraph {
 
@@ -29,16 +30,34 @@ public class StackNavGraph implements NavGraph {
     }
 
     @Override
+    public <T> void navigate(Screen screen, Consumer<T> consumer) {
+        try {
+            FXMLLoader loader = createLoader(screen);
+            Scene scene = createScene(loader);
+            consumer.accept(loader.getController());
+            show(backStack.push(scene));
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    @Override
     public void popBackStack() {
         backStack.pop();
         show(backStack.lastElement());
     }
 
     private Scene createScene(Screen screen) throws IOException {
-        FXMLLoader loader = new FXMLLoader(
-                getClass().getResource(screen.resource)
-        );
-        return new Scene(loader.load(), 300, 400);
+        FXMLLoader loader = createLoader(screen);
+        return createScene(loader);
+    }
+
+    private Scene createScene(FXMLLoader loader) throws IOException {
+        return new Scene(loader.load(), 300,  400);
+    }
+
+    private FXMLLoader createLoader(Screen screen) {
+        return new FXMLLoader(getClass().getResource(screen.resource));
     }
 
     private void show(Scene scene) {


### PR DESCRIPTION
issue: #9

사용 방법은 아래처럼 navigate 함수 안에 해당 뷰에 맞는 컨트롤러를 받아서 setArguments 함수처럼 전달해주면 됩니다.

``` Java
    // TetrisScreenController
    @FXML
    private void handleScoreButtonAction() {
        SE13Application.navController.navigate(Screen.RANKING, (RankingScreenController controller) -> {
            controller.setArguments(10);
        });
    }

    // RankingScreenController
    private int score;

    public void setArguments(int score) {
        this.score = score;
    }

    @Override
    public void initialize(URL location, ResourceBundle resources) {
        System.out.println("Score: " + score);
    }
```

주의 사항으로는 Initializable 인터페이스의 initialize 콜백이 setArguments 함수보다 먼저 실행됩니다.
즉 위 코드에서 Score 의 출력 값은 int의 기본값인 0이 출력됩니다.