### PR TITLE
exe 파일 추출 기능 추가

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
     id("java")
     id("application")
     id("org.openjfx.javafxplugin") version "0.0.13"
+    id("org.beryx.jlink") version "3.0.1"
 }
 
 group = "org.se13"


### PR DESCRIPTION
Gradle Task 중에 jpackage 를 실행하면 app/build/jpackage/app 폴더에 app.exe 파일이 생성됩니다.

다만 알 수 없는 이유로 이 태스크를 실행하고 나면 Gradle Clean이 이 build/jpackage/app 폴더를 삭제할 수 없습니다.

3시간정도 찾아보고 있긴 한데 해결법을 찾지 못해서 다음에 좀 더 찾아보겠습니다.