### PR TITLE
feat: Color Blind mode 추가

### DIFF
--- a/app/src/main/java/org/se13/game/block/Block.java
+++ b/app/src/main/java/org/se13/game/block/Block.java
@@ -1,54 +1,88 @@
 package org.se13.game.block;
 
+import javafx.scene.paint.Color;
+import org.se13.sqlite.config.ConfigRepositoryImpl;
+
+import java.util.Map;
+import java.util.Objects;
+
 public enum Block {
     IBlock(new int[][][]{
             {{1, 0}, {1, 1}, {1, 2}, {1, 3}},
             {{0, 2}, {1, 2}, {2, 2}, {3, 2}},
             {{2, 0}, {2, 1}, {2, 2}, {2, 3}},
             {{0, 1}, {1, 1}, {2, 1}, {3, 1}},
-    }, new int[]{0, 3}, 1, new BlockColor(67, 255, 255)),
+    }, new int[]{0, 3}, 1, new BlockColor (
+            Color.rgb(0, 0, 255),
+            Color.rgb(0, 0, 255),
+            Color.rgb(255, 0, 0))
+    ),
 
     JBlock(new int[][][]{
             {{0, 0}, {1, 0}, {1, 1}, {1, 2}},
             {{0, 1}, {0, 2}, {1, 1}, {2, 1}},
             {{1, 0}, {1, 1}, {1, 2}, {2, 2}},
             {{0, 1}, {1, 1}, {2, 0}, {2, 1}},
-    }, new int[]{0, 3}, 2, new BlockColor(0, 1, 252)),
+    }, new int[]{0, 3}, 2, new BlockColor(
+            Color.rgb(255, 0, 0),
+            Color.rgb(255, 192, 203),
+            Color.rgb(0, 255, 0))
+    ),
 
     LBlock(new int[][][]{
             {{0, 2}, {1, 0}, {1, 1}, {1, 2}},
             {{0, 1}, {1, 1}, {2, 1}, {2, 2}},
             {{1, 0}, {1, 1}, {1, 2}, {2, 0}},
             {{0, 0}, {0, 1}, {1, 1}, {2, 1}},
-    }, new int[]{0, 3}, 3, new BlockColor(254, 165, 0)),
+    }, new int[]{0, 3}, 3, new BlockColor(
+            Color.rgb(0, 255, 0),
+            Color.rgb(0, 128, 128),
+            Color.rgb(128, 0, 128))
+    ),
 
     OBlock(new int[][][]{
             {{0, 0}, {0, 1}, {1, 0}, {1, 1}},
             {{0, 0}, {0, 1}, {1, 0}, {1, 1}},
             {{0, 0}, {0, 1}, {1, 0}, {1, 1}},
             {{0, 0}, {0, 1}, {1, 0}, {1, 1}},
-    }, new int[]{0, 3}, 4, new BlockColor(255, 255, 0)),
+    }, new int[]{0, 3}, 4, new BlockColor(
+            Color.rgb(255, 255, 0),
+            Color.rgb(255, 255, 0),
+            Color.rgb(135, 206, 235))
+    ),
 
     SBlock(new int[][][]{
             {{0, 1}, {0, 2}, {1, 0}, {1, 1}},
             {{0, 1}, {1, 1}, {1, 2}, {2, 2}},
             {{1, 1}, {1, 2}, {2, 0}, {2, 1}},
             {{0, 0}, {1, 0}, {1, 1}, {2, 1}},
-    }, new int[]{0, 3}, 5, new BlockColor(0, 255, 1)),
+    }, new int[]{0, 3}, 5, new BlockColor(
+            Color.rgb(255, 165, 0),
+            Color.rgb(128, 0, 128),
+            Color.rgb(255, 165,0))
+    ),
 
     TBlock(new int[][][]{
             {{0, 1}, {1, 0}, {1, 1}, {1, 2}},
             {{0, 1}, {1, 1}, {1, 2}, {2, 1}},
             {{1, 0}, {1, 1}, {1, 2}, {2, 1}},
             {{0, 1}, {1, 0}, {1, 1}, {2, 1}},
-    }, new int[]{0, 3}, 6, new BlockColor(170, 0, 255)),
+    }, new int[]{0, 3}, 6, new BlockColor(
+            Color.rgb(135, 206, 235),
+            Color.rgb(173, 216, 230),
+            Color.rgb(255, 255, 224))
+    ),
 
     ZBlock(new int[][][]{
             {{0, 0}, {0, 1}, {1, 1}, {1, 2}},
             {{0, 2}, {1, 1}, {1, 2}, {2, 1}},
             {{1, 0}, {1, 1}, {2, 1}, {2, 2}},
             {{0, 1}, {1, 0}, {1, 1}, {2, 0}},
-    }, new int[]{0, 3}, 7, new BlockColor(254,0, 0));
+    }, new int[]{0, 3}, 7, new BlockColor(
+            Color.rgb(128, 0, 128),
+            Color.rgb(255, 200, 100),
+            Color.rgb(192, 192, 192))
+    );
 
     Block(int[][][] positions, int[] offset, int id, BlockColor blockColor) {
         int row = positions.length;
@@ -56,7 +90,12 @@ public enum Block {
         blockId = id;
         cells = new BlockPosition[row][];
         startOffset = new BlockPosition(offset[0], offset[1]);
-        this.blockColor = blockColor;
+        ConfigRepositoryImpl configRepository = ConfigRepositoryImpl.getInstance();
+        Map<String, Object> configs = configRepository.getConfig(0);
+        String colorMode = (String) configs.get("mode");
+        if (Objects.equals(colorMode, "Red-green")) {
+            this.blockColor = blockColor;
+        }
 
         for (int r = 0; r < row; r++) {
             int col = positions[r].length;
@@ -67,10 +106,11 @@ public enum Block {
         }
     }
 
+
     public final int blockId;
     public final BlockPosition[][] cells;
     public final BlockPosition startOffset;
-    public final BlockColor blockColor;
+    public BlockColor blockColor;
 
     public BlockPosition[] shape(int rotate) {
         return cells[rotate % cells.length];

--- a/app/src/main/java/org/se13/game/block/BlockColor.java
+++ b/app/src/main/java/org/se13/game/block/BlockColor.java
@@ -1,22 +1,32 @@
 package org.se13.game.block;
 
 import javafx.scene.paint.Color;
+import org.se13.sqlite.config.ConfigRepositoryImpl;
+
+import java.util.Map;
+import java.util.Objects;
 
 public class BlockColor {
-    BlockColor(int red, int green, int blue) {
-        this.defaultBlockColor = Color.rgb(red, green, blue);
-        this.isColorBlindMode = false;
+    public BlockColor(Color defaultColor, Color redGreenColorBlindColor, Color blueYellowColorBlindColor) {
+        this.defaultColor = defaultColor;
+        this.redGreenColorBlindColor = redGreenColorBlindColor;
+        this.blueYellowColorBlindColor = blueYellowColorBlindColor;
     }
 
     public Color getBlockColor() {
-        if (this.isColorBlindMode == true) {
-            return this.colorBlindModeBlockColor;
+        ConfigRepositoryImpl configRepository = ConfigRepositoryImpl.getInstance();
+        Map<String, Object> configs = configRepository.getConfig(0);
+        String colorMode = (String) configs.get("mode");
+        if (Objects.equals(colorMode, "Red-green")) {
+            return redGreenColorBlindColor;
+        } else if (Objects.equals(colorMode, "Blue-yellow")) {
+            return blueYellowColorBlindColor;
         } else {
-            return this.defaultBlockColor;
+            return defaultColor;
         }
     }
 
-    private Color defaultBlockColor;
-    private Color colorBlindModeBlockColor;
-    private boolean isColorBlindMode;
+    private final Color defaultColor;
+    private final Color redGreenColorBlindColor; // 적록색맹용 색상
+    private final Color blueYellowColorBlindColor; // 청황색맹용 색상
 }

--- a/app/src/main/java/org/se13/game/block/ColorMode.java
+++ b/app/src/main/java/org/se13/game/block/ColorMode.java
@@ -1,0 +1,7 @@
+package org.se13.game.block;
+
+public enum ColorMode {
+    DEFAULT,
+    RED_GREEN_COLORBLIND,
+    BLUE_YELLOW_COLORBLIND
+}

--- a/app/src/main/java/org/se13/view/setting/SettingScreenController.java
+++ b/app/src/main/java/org/se13/view/setting/SettingScreenController.java
@@ -42,8 +42,6 @@ public class SettingScreenController extends BaseController {
         screenColorBlindChoiceBox.setValue(colorMode);
         // Add options in buttons for the choice in the keyboard
 
-        moveLeftButton.setText("Left: " + configs.get("keyLeft"));
-        moveRightButton.setText("Right: " + configs.get("keyRight"));
 
         // By selected scene size, the function will implement logic.
 


### PR DESCRIPTION
#31 
config로 값을 받아와서 색맹모드 2가지 적록색맹, 청황색맹에 따라 색깔을 결정할 수 있는 로직을 만들었습니다. 아래는 사용한 색깔 조합입니다. 
## Default 모드
파란색: RGB(0, 0, 255) (변경 없음)
빨간색: RGB(255, 0, 0) (변경 없음)
녹색: RGB(0, 255, 0) (변경 없음)
노란색: RGB(255, 255, 0) (변경 없음)
오렌지색: RGB(255, 165, 0) (변경 없음)
하늘색: RGB(135, 206, 235) (변경 없음)
보라색: RGB(128, 0, 128) (변경 없음)
## 적록색맹 (Protanopia, Deuteranopia) 모드
파란색: RGB(0, 0, 255) (변경 없음)
분홍색: RGB(255, 192, 203) (변경 없음)
틸 (청록색): RGB(0, 128, 128) (변경 없음)
노란색: RGB(255, 255, 0) (변경 없음)
보라색: RGB(128, 0, 128) (변경 없음)
밝은 파란색: RGB(173, 216, 230) (회색 대신)
밝은 오렌지: RGB(255, 200, 100) (갈색 대신)
## 청황색맹 (Tritanopia) 모드를 위한 대체 색상:
빨간색: RGB(255, 0, 0)
녹색: RGB(0, 255, 0)
보라색: RGB(128, 0, 128)
하늘색: RGB(135, 206, 235) (밝고, 배경과 대조되는 색상)
오렌지색: RGB(255, 165, 0)
밝은 노란색: RGB(255, 255, 224) (배경과 대조되는 밝은 색상)
밝은 회색: RGB(192, 192, 192) (배경과 구별되는 밝은 색상)