### PR TITLE
전체적인 테트리스 구조 리팩토링

### DIFF
--- a/app/src/main/java/org/se13/game/action/TetrisAction.java
+++ b/app/src/main/java/org/se13/game/action/TetrisAction.java
@@ -1,7 +1,6 @@
 package org.se13.game.action;
 
 public enum TetrisAction {
-
     START,
     IMMEDIATE_BLOCK_PLACE,
     MOVE_BLOCK_DOWN,

--- a/app/src/main/java/org/se13/game/action/TetrisAction.java
+++ b/app/src/main/java/org/se13/game/action/TetrisAction.java
@@ -2,7 +2,7 @@ package org.se13.game.action;
 
 public enum TetrisAction {
 
-    CONNECT,
+    START,
     IMMEDIATE_BLOCK_PLACE,
     MOVE_BLOCK_DOWN,
     MOVE_BLOCK_LEFT,

--- a/app/src/main/java/org/se13/game/action/TetrisAction.java
+++ b/app/src/main/java/org/se13/game/action/TetrisAction.java
@@ -1,0 +1,13 @@
+package org.se13.game.action;
+
+public enum TetrisAction {
+
+    CONNECT,
+    IMMEDIATE_BLOCK_PLACE,
+    MOVE_BLOCK_DOWN,
+    MOVE_BLOCK_LEFT,
+    MOVE_BLOCK_RIGHT,
+    ROTATE_BLOCK_CW,
+    TOGGLE_PAUSE_STATE,
+    EXIT_GAME,
+}

--- a/app/src/main/java/org/se13/game/grid/TetrisGrid.java
+++ b/app/src/main/java/org/se13/game/grid/TetrisGrid.java
@@ -20,6 +20,10 @@ public class TetrisGrid {
         this.listeners = new ArrayList<>();
     }
 
+    public CellID[][] getGrid() {
+        return gridCells;
+    }
+
     public void setCell(int rowIndex, int colIndex, CellID cellId) {
         gridCells[rowIndex][colIndex] = cellId;
     }

--- a/app/src/main/java/org/se13/game/input/InputManager.java
+++ b/app/src/main/java/org/se13/game/input/InputManager.java
@@ -1,43 +1,30 @@
 package org.se13.game.input;
 
-import javafx.scene.Scene;
-import javafx.scene.input.KeyCode;
-import javafx.scene.input.KeyEvent;
+import org.se13.game.action.TetrisAction;
 
 import java.util.LinkedList;
 import java.util.Queue;
 
 public class InputManager {
-    private InputManager(Scene scene) {
+    public InputManager() {
         keyCodeQueue = new LinkedList<>();
-
-        if (scene != null) {
-            scene.addEventHandler(KeyEvent.KEY_PRESSED, (key) -> {
-                keyCodeQueue.add(key.getCode().getName().toLowerCase());
-            });
-        }
     }
 
-    public static InputManager getInstance(Scene scene) {
-        if (inputManager == null) {
-            inputManager = new InputManager(scene);
-        }
-
-        return inputManager;
+    public void add(TetrisAction input) {
+        keyCodeQueue.add(input);
     }
 
     public void reset() {
-        inputManager = null;
+        keyCodeQueue.clear();
     }
 
     public boolean peekInput() {
         return keyCodeQueue.peek() != null;
     }
 
-    public String getInput() {
+    public TetrisAction getInput() {
         return keyCodeQueue.poll();
     }
 
-    private static InputManager inputManager;
-    private Queue<String> keyCodeQueue;
+    private Queue<TetrisAction> keyCodeQueue;
 }

--- a/app/src/main/java/org/se13/server/LocalBattleTetrisServer.java
+++ b/app/src/main/java/org/se13/server/LocalBattleTetrisServer.java
@@ -1,0 +1,45 @@
+package org.se13.server;
+
+import org.se13.game.rule.GameLevel;
+import org.se13.game.rule.GameMode;
+import org.se13.game.tetris.DefaultTetrisGame;
+
+import java.util.Map;
+
+public class LocalBattleTetrisServer implements TetrisServer {
+
+    private GameLevel level;
+    private GameMode mode;
+
+    private Map<Integer, TetrisRoom> sessions;
+
+    public LocalBattleTetrisServer(GameLevel level, GameMode mode) {
+        this.level = level;
+        this.mode = mode;
+    }
+
+    @Override
+    public void responseGameOver(int score, boolean isItemMode, String difficulty) {
+
+    }
+
+    @Override
+    public TetrisActionHandler connect(TetrisClient client) {
+        sessions.put(client.getUserId(), new TetrisRoom(client, new DefaultTetrisGame(level, mode, this)));
+
+        return packet -> {
+            switch (packet.action()) {
+                case START -> handleStartGame(packet.userId());
+            }
+        };
+    }
+
+    @Override
+    public void disconnect(TetrisClient client) {
+        sessions.remove(client.getUserId());
+    }
+
+    public void handleStartGame(int userId) {
+        sessions.get(userId).startGame();
+    }
+}

--- a/app/src/main/java/org/se13/server/LocalBattleTetrisServer.java
+++ b/app/src/main/java/org/se13/server/LocalBattleTetrisServer.java
@@ -40,6 +40,6 @@ public class LocalBattleTetrisServer implements TetrisServer {
     }
 
     public void handleStartGame(int userId) {
-        sessions.get(userId).startGame();
+
     }
 }

--- a/app/src/main/java/org/se13/server/LocalTetrisServer.java
+++ b/app/src/main/java/org/se13/server/LocalTetrisServer.java
@@ -1,14 +1,15 @@
 package org.se13.server;
 
-import javafx.animation.AnimationTimer;
 import org.se13.game.action.TetrisAction;
 import org.se13.game.rule.GameLevel;
 import org.se13.game.rule.GameMode;
 import org.se13.game.tetris.DefaultTetrisGame;
 
+import java.util.Timer;
+import java.util.TimerTask;
+
 public class LocalTetrisServer implements TetrisServer {
-    // TODO: JavaFX 의존성이 없는 Timer로 교체해야 합니다.
-    private AnimationTimer tetrisTimer;
+    private Timer tetrisTimer;
     private TetrisClient client;
     private DefaultTetrisGame tetrisGame;
 
@@ -16,12 +17,13 @@ public class LocalTetrisServer implements TetrisServer {
         this.client = client;
         this.tetrisGame = new DefaultTetrisGame(gameLevel, gameMode, this);
         this.tetrisGame.subscribe(client::response);
+        tetrisTimer = new Timer();
     }
 
     @Override
     public void responseGameOver(int score, boolean isItemMode, String difficulty) {
         this.client.gameOver(score, isItemMode, difficulty);
-        tetrisTimer.stop();
+        tetrisTimer.cancel();
     }
 
     @Override
@@ -40,21 +42,24 @@ public class LocalTetrisServer implements TetrisServer {
 
     private void startGame() {
         tetrisGame.startGame();
-        tetrisTimer = new AnimationTimer() {
-            @Override
-            public void handle(long l) {
-                tetrisGame.pulse(l);
-            }
-        };
-        tetrisTimer.start();
+        schedule();
     }
 
     private void togglePauseState() {
-        tetrisGame.togglePauseState();
         if (tetrisGame.togglePauseState()) {
-            tetrisTimer.start();
+            schedule();
         } else {
-            tetrisTimer.stop();
+            tetrisTimer.cancel();
         }
+    }
+
+    private void schedule() {
+        tetrisTimer = new Timer();
+        tetrisTimer.schedule(new TimerTask() {
+            @Override
+            public void run() {
+                tetrisGame.pulse(System.nanoTime());
+            }
+        }, 0, 16);
     }
 }

--- a/app/src/main/java/org/se13/server/LocalTetrisServer.java
+++ b/app/src/main/java/org/se13/server/LocalTetrisServer.java
@@ -1,0 +1,60 @@
+package org.se13.server;
+
+import javafx.animation.AnimationTimer;
+import org.se13.game.action.TetrisAction;
+import org.se13.game.rule.GameLevel;
+import org.se13.game.rule.GameMode;
+import org.se13.game.tetris.DefaultTetrisGame;
+
+public class LocalTetrisServer implements TetrisServer {
+    // TODO: JavaFX 의존성이 없는 Timer로 교체해야 합니다.
+    private AnimationTimer tetrisTimer;
+    private TetrisClient client;
+    private DefaultTetrisGame tetrisGame;
+
+    public LocalTetrisServer(GameLevel gameLevel, GameMode gameMode, TetrisClient client) {
+        this.client = client;
+        this.tetrisGame = new DefaultTetrisGame(gameLevel, gameMode, this);
+        this.tetrisGame.subscribe(client::response);
+    }
+
+    @Override
+    public void responseGameOver(int score, boolean isItemMode, String difficulty) {
+        this.client.gameOver(score, isItemMode, difficulty);
+        tetrisTimer.stop();
+    }
+
+    @Override
+    public void handle(TetrisAction request) {
+        switch (request) {
+            case CONNECT -> startGame();
+            case EXIT_GAME -> tetrisGame.stopGame();
+            case TOGGLE_PAUSE_STATE -> togglePauseState();
+            case IMMEDIATE_BLOCK_PLACE,
+                 MOVE_BLOCK_DOWN,
+                 MOVE_BLOCK_LEFT,
+                 MOVE_BLOCK_RIGHT,
+                 ROTATE_BLOCK_CW -> tetrisGame.requestInput(request);
+        }
+    }
+
+    private void startGame() {
+        tetrisGame.startGame();
+        tetrisTimer = new AnimationTimer() {
+            @Override
+            public void handle(long l) {
+                tetrisGame.pulse(l);
+            }
+        };
+        tetrisTimer.start();
+    }
+
+    private void togglePauseState() {
+        tetrisGame.togglePauseState();
+        if (tetrisGame.togglePauseState()) {
+            tetrisTimer.start();
+        } else {
+            tetrisTimer.stop();
+        }
+    }
+}

--- a/app/src/main/java/org/se13/server/TetrisActionHandler.java
+++ b/app/src/main/java/org/se13/server/TetrisActionHandler.java
@@ -1,0 +1,9 @@
+package org.se13.server;
+
+import org.se13.game.action.TetrisAction;
+
+public interface TetrisActionHandler {
+
+    // 원래라면 네트워크 전송을 위해 패킷을 수신해야 하지만 현재론 로컬 게임만 있으므로 TetrisAction을 사용함.
+    void handle(TetrisAction request);
+}

--- a/app/src/main/java/org/se13/server/TetrisActionHandler.java
+++ b/app/src/main/java/org/se13/server/TetrisActionHandler.java
@@ -1,9 +1,7 @@
 package org.se13.server;
 
-import org.se13.game.action.TetrisAction;
-
+@FunctionalInterface
 public interface TetrisActionHandler {
 
-    // 원래라면 네트워크 전송을 위해 패킷을 수신해야 하지만 현재론 로컬 게임만 있으므로 TetrisAction을 사용함.
-    void handle(TetrisAction request);
+    void request(TetrisActionPacket packet);
 }

--- a/app/src/main/java/org/se13/server/TetrisActionPacket.java
+++ b/app/src/main/java/org/se13/server/TetrisActionPacket.java
@@ -1,0 +1,7 @@
+package org.se13.server;
+
+import org.se13.game.action.TetrisAction;
+
+public record TetrisActionPacket(int userId, TetrisAction action) {
+
+}

--- a/app/src/main/java/org/se13/server/TetrisClient.java
+++ b/app/src/main/java/org/se13/server/TetrisClient.java
@@ -9,7 +9,8 @@ public class TetrisClient {
     private int userId;
     private TetrisStateRepository repository;
 
-    public TetrisClient(TetrisStateRepository repository) {
+    public TetrisClient(int userId, TetrisStateRepository repository) {
+        this.userId = userId;
         this.repository = repository;
     }
 

--- a/app/src/main/java/org/se13/server/TetrisClient.java
+++ b/app/src/main/java/org/se13/server/TetrisClient.java
@@ -1,0 +1,22 @@
+package org.se13.server;
+
+import org.se13.view.tetris.TetrisGameEndData;
+import org.se13.view.tetris.TetrisState;
+import org.se13.view.tetris.TetrisStateRepository;
+
+public class TetrisClient {
+
+    private TetrisStateRepository repository;
+
+    public TetrisClient(TetrisStateRepository repository) {
+        this.repository = repository;
+    }
+
+    public void response(TetrisState state) {
+        repository.response(state);
+    }
+
+    public void gameOver(int score, boolean isItemMode, String difficulty) {
+        repository.gameOver(new TetrisGameEndData(score, isItemMode, difficulty));
+    }
+}

--- a/app/src/main/java/org/se13/server/TetrisClient.java
+++ b/app/src/main/java/org/se13/server/TetrisClient.java
@@ -6,6 +6,7 @@ import org.se13.view.tetris.TetrisStateRepository;
 
 public class TetrisClient {
 
+    private int userId;
     private TetrisStateRepository repository;
 
     public TetrisClient(TetrisStateRepository repository) {
@@ -18,5 +19,9 @@ public class TetrisClient {
 
     public void gameOver(int score, boolean isItemMode, String difficulty) {
         repository.gameOver(new TetrisGameEndData(score, isItemMode, difficulty));
+    }
+
+    public int getUserId() {
+        return userId;
     }
 }

--- a/app/src/main/java/org/se13/server/TetrisRoom.java
+++ b/app/src/main/java/org/se13/server/TetrisRoom.java
@@ -12,19 +12,7 @@ public class TetrisRoom {
     public TetrisRoom(TetrisClient player, DefaultTetrisGame playerGame) {
         this.player = player;
         this.playerGame = playerGame;
-    }
-
-    public TetrisActionHandler connect() {
-        return request -> {
-            switch (request.action()) {
-                case START -> isPlayerReady = true;
-                case EXIT_GAME -> isPlayerReady = false;
-            }
-        };
-    }
-
-    public boolean isPlayerReady() {
-        return isPlayerReady;
+        playerGame.subscribe(player::response);
     }
 
     public void startGame() {

--- a/app/src/main/java/org/se13/server/TetrisRoom.java
+++ b/app/src/main/java/org/se13/server/TetrisRoom.java
@@ -1,0 +1,33 @@
+package org.se13.server;
+
+import org.se13.game.tetris.DefaultTetrisGame;
+
+public class TetrisRoom {
+
+    private TetrisClient player;
+    private DefaultTetrisGame playerGame;
+
+    private boolean isPlayerReady;
+
+    public TetrisRoom(TetrisClient player, DefaultTetrisGame playerGame) {
+        this.player = player;
+        this.playerGame = playerGame;
+    }
+
+    public TetrisActionHandler connect() {
+        return request -> {
+            switch (request.action()) {
+                case START -> isPlayerReady = true;
+                case EXIT_GAME -> isPlayerReady = false;
+            }
+        };
+    }
+
+    public boolean isPlayerReady() {
+        return isPlayerReady;
+    }
+
+    public void startGame() {
+        playerGame.startGame();
+    }
+}

--- a/app/src/main/java/org/se13/server/TetrisServer.java
+++ b/app/src/main/java/org/se13/server/TetrisServer.java
@@ -1,0 +1,8 @@
+package org.se13.server;
+
+import org.se13.game.rule.GameLevel;
+
+public interface TetrisServer extends TetrisActionHandler {
+
+    void responseGameOver(int score, boolean isItemMode, String difficulty);
+}

--- a/app/src/main/java/org/se13/server/TetrisServer.java
+++ b/app/src/main/java/org/se13/server/TetrisServer.java
@@ -1,8 +1,10 @@
 package org.se13.server;
 
-import org.se13.game.rule.GameLevel;
+public interface TetrisServer {
 
-public interface TetrisServer extends TetrisActionHandler {
+    TetrisActionHandler connect(TetrisClient client);
+
+    void disconnect(TetrisClient client);
 
     void responseGameOver(int score, boolean isItemMode, String difficulty);
 }

--- a/app/src/main/java/org/se13/utils/Observer.java
+++ b/app/src/main/java/org/se13/utils/Observer.java
@@ -1,0 +1,20 @@
+package org.se13.utils;
+
+public class Observer<T> {
+    private T value;
+
+    private Subscriber<T> subscriber = new Subscriber.EmptySubscriber<>();
+
+    public void setValue(T value) {
+        this.value = value;
+        subscriber.collect(this.value);
+    }
+
+    public T getValue() {
+        return value;
+    }
+
+    public void subscribe(Subscriber<T> subscriber) {
+        this.subscriber = subscriber;
+    }
+}

--- a/app/src/main/java/org/se13/utils/Subscriber.java
+++ b/app/src/main/java/org/se13/utils/Subscriber.java
@@ -1,0 +1,14 @@
+package org.se13.utils;
+
+@FunctionalInterface
+public interface Subscriber<T> {
+    void collect(T value);
+
+    public static class EmptySubscriber<T> implements Subscriber<T> {
+
+        @Override
+        public void collect(T value) {
+
+        }
+    }
+}

--- a/app/src/main/java/org/se13/view/difficulty/LevelSelectScreenController.java
+++ b/app/src/main/java/org/se13/view/difficulty/LevelSelectScreenController.java
@@ -8,6 +8,7 @@ import org.se13.SE13Application;
 import org.se13.game.rule.GameLevel;
 import org.se13.game.rule.GameMode;
 import org.se13.server.LocalTetrisServer;
+import org.se13.server.TetrisActionHandler;
 import org.se13.server.TetrisClient;
 import org.se13.view.base.BaseController;
 import org.se13.view.nav.AppScreen;
@@ -38,8 +39,9 @@ public class LevelSelectScreenController extends BaseController {
     private void startLocalTetrisGame(GameLevel level, GameMode mode) {
         TetrisStateRepository stateRepository = new TetrisStateRepositoryImpl();
         TetrisClient client = new TetrisClient(stateRepository);
-        LocalTetrisServer server = new LocalTetrisServer(level, mode, client);
-        TetrisActionRepository actionRepository = new TetrisActionRepositoryImpl(server);
+        LocalTetrisServer server = new LocalTetrisServer(level, mode);
+        TetrisActionHandler handler = server.connect(client);
+        TetrisActionRepository actionRepository = new TetrisActionRepositoryImpl(-1, handler);
 
         SE13Application.navController.navigate(AppScreen.TETRIS, (controller) -> {
             ((TetrisScreenController) controller).setArguments(actionRepository, stateRepository);

--- a/app/src/main/java/org/se13/view/difficulty/LevelSelectScreenController.java
+++ b/app/src/main/java/org/se13/view/difficulty/LevelSelectScreenController.java
@@ -38,10 +38,10 @@ public class LevelSelectScreenController extends BaseController {
 
     private void startLocalTetrisGame(GameLevel level, GameMode mode) {
         TetrisStateRepository stateRepository = new TetrisStateRepositoryImpl();
-        TetrisClient client = new TetrisClient(stateRepository);
+        TetrisClient client = new TetrisClient(-1, stateRepository);
         LocalTetrisServer server = new LocalTetrisServer(level, mode);
         TetrisActionHandler handler = server.connect(client);
-        TetrisActionRepository actionRepository = new TetrisActionRepositoryImpl(-1, handler);
+        TetrisActionRepository actionRepository = new TetrisActionRepositoryImpl(client.getUserId(), handler);
 
         SE13Application.navController.navigate(AppScreen.TETRIS, (controller) -> {
             ((TetrisScreenController) controller).setArguments(actionRepository, stateRepository);

--- a/app/src/main/java/org/se13/view/difficulty/LevelSelectScreenController.java
+++ b/app/src/main/java/org/se13/view/difficulty/LevelSelectScreenController.java
@@ -7,8 +7,11 @@ import javafx.scene.control.ChoiceBox;
 import org.se13.SE13Application;
 import org.se13.game.rule.GameLevel;
 import org.se13.game.rule.GameMode;
+import org.se13.server.LocalTetrisServer;
+import org.se13.server.TetrisClient;
 import org.se13.view.base.BaseController;
 import org.se13.view.nav.AppScreen;
+import org.se13.view.tetris.*;
 
 public class LevelSelectScreenController extends BaseController {
     @FXML
@@ -19,23 +22,28 @@ public class LevelSelectScreenController extends BaseController {
 
     @FXML
     private void handleEasyButtonAction() {
-        gameLevel = GameLevel.EASY;
-        gameMode = setGameMode(modeChoiceBox.getValue());
-        SE13Application.navController.navigate(AppScreen.TETRIS);
+        startLocalTetrisGame(GameLevel.EASY, setGameMode(modeChoiceBox.getValue()));
     }
 
     @FXML
     private void handleNormalButtonAction() {
-        gameLevel = GameLevel.NORMAL;
-        gameMode = setGameMode(modeChoiceBox.getValue());
-        SE13Application.navController.navigate(AppScreen.TETRIS);
+        startLocalTetrisGame(GameLevel.NORMAL, setGameMode(modeChoiceBox.getValue()));
     }
 
     @FXML
     private void handleHardButtonAction() {
-        gameLevel = GameLevel.HARD;
-        gameMode = setGameMode(modeChoiceBox.getValue());
-        SE13Application.navController.navigate(AppScreen.TETRIS);
+        startLocalTetrisGame(GameLevel.HARD, setGameMode(modeChoiceBox.getValue()));
+    }
+
+    private void startLocalTetrisGame(GameLevel level, GameMode mode) {
+        TetrisStateRepository stateRepository = new TetrisStateRepositoryImpl();
+        TetrisClient client = new TetrisClient(stateRepository);
+        LocalTetrisServer server = new LocalTetrisServer(level, mode, client);
+        TetrisActionRepository actionRepository = new TetrisActionRepositoryImpl(server);
+
+        SE13Application.navController.navigate(AppScreen.TETRIS, (controller) -> {
+            ((TetrisScreenController) controller).setArguments(actionRepository, stateRepository);
+        });
     }
 
     private GameMode setGameMode(String gameMode) {

--- a/app/src/main/java/org/se13/view/tetris/GameOverScreenController.java
+++ b/app/src/main/java/org/se13/view/tetris/GameOverScreenController.java
@@ -4,35 +4,36 @@ import javafx.fxml.FXML;
 import javafx.scene.control.Button;
 import javafx.scene.text.Text;
 import org.se13.SE13Application;
-import org.se13.game.tetris.DefaultTetrisGame;
 import org.se13.sqlite.ranking.RankingRepositoryImpl;
-import org.se13.view.ranking.RankingScreenController;
 import org.se13.view.base.BaseController;
 import org.se13.view.nav.AppScreen;
+import org.se13.view.ranking.RankingScreenController;
 
 public class GameOverScreenController extends BaseController {
     @Override
     public void onStart() {
         super.onStart();
-
-        defaultTetrisGame = DefaultTetrisGame.getInstance(null, null, null, null, null, null,false);
-        score.setText(String.valueOf(defaultTetrisGame.getScore()));
+        score.setText(String.valueOf(endData.score()));
         rankingRepository = new RankingRepositoryImpl();
         rankingRepository.createNewTableRanking();
     }
 
     public void handleRankingButtonAction() {
         SE13Application.navController.navigate(AppScreen.RANKING, (RankingScreenController controller) -> {
-            controller.setArguments(defaultTetrisGame.getScore(), defaultTetrisGame.isItemMode(), defaultTetrisGame.getDifficulty());
+            controller.setArguments(endData.score(), endData.isItemMode(), endData.difficulty());
         });
-        defaultTetrisGame.resetGame();
     }
 
-    private DefaultTetrisGame defaultTetrisGame;
+    public void setArguments(TetrisGameEndData endData) {
+        this.endData = endData;
+    }
+
     private RankingRepositoryImpl rankingRepository;
 
     @FXML
     private Text score;
     @FXML
     public Button rankingButton;
+
+    private TetrisGameEndData endData;
 }

--- a/app/src/main/java/org/se13/view/tetris/TetrisActionRepository.java
+++ b/app/src/main/java/org/se13/view/tetris/TetrisActionRepository.java
@@ -1,0 +1,20 @@
+package org.se13.view.tetris;
+
+public interface TetrisActionRepository {
+
+    void connect();
+
+    void immediateBlockPlace();
+
+    void moveBlockDown();
+
+    void moveBlockLeft();
+
+    void moveBlockRight();
+
+    void rotateBlockCW();
+
+    void togglePauseState();
+
+    void exitGame();
+}

--- a/app/src/main/java/org/se13/view/tetris/TetrisActionRepositoryImpl.java
+++ b/app/src/main/java/org/se13/view/tetris/TetrisActionRepositoryImpl.java
@@ -1,0 +1,53 @@
+package org.se13.view.tetris;
+
+import org.se13.game.action.TetrisAction;
+import org.se13.server.TetrisServer;
+
+public class TetrisActionRepositoryImpl implements TetrisActionRepository {
+
+    private TetrisServer server;
+
+    public TetrisActionRepositoryImpl(TetrisServer server) {
+        this.server = server;
+    }
+
+    @Override
+    public void connect() {
+        server.handle(TetrisAction.CONNECT);
+    }
+
+    @Override
+    public void immediateBlockPlace() {
+        server.handle(TetrisAction.IMMEDIATE_BLOCK_PLACE);
+    }
+
+    @Override
+    public void moveBlockDown() {
+        server.handle(TetrisAction.MOVE_BLOCK_DOWN);
+    }
+
+    @Override
+    public void moveBlockLeft() {
+        server.handle(TetrisAction.MOVE_BLOCK_LEFT);
+    }
+
+    @Override
+    public void moveBlockRight() {
+        server.handle(TetrisAction.MOVE_BLOCK_RIGHT);
+    }
+
+    @Override
+    public void rotateBlockCW() {
+        server.handle(TetrisAction.ROTATE_BLOCK_CW);
+    }
+
+    @Override
+    public void togglePauseState() {
+        server.handle(TetrisAction.TOGGLE_PAUSE_STATE);
+    }
+
+    @Override
+    public void exitGame() {
+        server.handle(TetrisAction.EXIT_GAME);
+    }
+}

--- a/app/src/main/java/org/se13/view/tetris/TetrisActionRepositoryImpl.java
+++ b/app/src/main/java/org/se13/view/tetris/TetrisActionRepositoryImpl.java
@@ -1,53 +1,56 @@
 package org.se13.view.tetris;
 
 import org.se13.game.action.TetrisAction;
-import org.se13.server.TetrisServer;
+import org.se13.server.TetrisActionHandler;
+import org.se13.server.TetrisActionPacket;
 
 public class TetrisActionRepositoryImpl implements TetrisActionRepository {
 
-    private TetrisServer server;
+    private int userId;
+    private TetrisActionHandler handler;
 
-    public TetrisActionRepositoryImpl(TetrisServer server) {
-        this.server = server;
+    public TetrisActionRepositoryImpl(int userId, TetrisActionHandler handler) {
+        this.userId = userId;
+        this.handler = handler;
     }
 
     @Override
     public void connect() {
-        server.handle(TetrisAction.CONNECT);
+        handler.request(new TetrisActionPacket(userId, TetrisAction.START));
     }
 
     @Override
     public void immediateBlockPlace() {
-        server.handle(TetrisAction.IMMEDIATE_BLOCK_PLACE);
+        handler.request(new TetrisActionPacket(userId, TetrisAction.IMMEDIATE_BLOCK_PLACE));
     }
 
     @Override
     public void moveBlockDown() {
-        server.handle(TetrisAction.MOVE_BLOCK_DOWN);
+        handler.request(new TetrisActionPacket(userId, TetrisAction.MOVE_BLOCK_DOWN));
     }
 
     @Override
     public void moveBlockLeft() {
-        server.handle(TetrisAction.MOVE_BLOCK_LEFT);
+        handler.request(new TetrisActionPacket(userId, TetrisAction.MOVE_BLOCK_LEFT));
     }
 
     @Override
     public void moveBlockRight() {
-        server.handle(TetrisAction.MOVE_BLOCK_RIGHT);
+        handler.request(new TetrisActionPacket(userId, TetrisAction.MOVE_BLOCK_RIGHT));
     }
 
     @Override
     public void rotateBlockCW() {
-        server.handle(TetrisAction.ROTATE_BLOCK_CW);
+        handler.request(new TetrisActionPacket(userId, TetrisAction.ROTATE_BLOCK_CW));
     }
 
     @Override
     public void togglePauseState() {
-        server.handle(TetrisAction.TOGGLE_PAUSE_STATE);
+        handler.request(new TetrisActionPacket(userId, TetrisAction.TOGGLE_PAUSE_STATE));
     }
 
     @Override
     public void exitGame() {
-        server.handle(TetrisAction.EXIT_GAME);
+        handler.request(new TetrisActionPacket(userId, TetrisAction.EXIT_GAME));
     }
 }

--- a/app/src/main/java/org/se13/view/tetris/TetrisGameEndData.java
+++ b/app/src/main/java/org/se13/view/tetris/TetrisGameEndData.java
@@ -1,0 +1,5 @@
+package org.se13.view.tetris;
+
+public record TetrisGameEndData(int score, boolean isItemMode, String difficulty) {
+
+}

--- a/app/src/main/java/org/se13/view/tetris/TetrisScreenController.java
+++ b/app/src/main/java/org/se13/view/tetris/TetrisScreenController.java
@@ -105,8 +105,10 @@ public class TetrisScreenController extends BaseController {
 
     private Subscriber<TetrisGameEndData> bindGameEnd() {
         return (endData) -> {
-            SE13Application.navController.navigate(AppScreen.GAMEOVER, (GameOverScreenController controller) -> {
-                controller.setArguments(endData);
+            Platform.runLater(() -> {
+                SE13Application.navController.navigate(AppScreen.GAMEOVER, (GameOverScreenController controller) -> {
+                    controller.setArguments(endData);
+                });
             });
         };
     }

--- a/app/src/main/java/org/se13/view/tetris/TetrisScreenController.java
+++ b/app/src/main/java/org/se13/view/tetris/TetrisScreenController.java
@@ -1,5 +1,6 @@
 package org.se13.view.tetris;
 
+import javafx.application.Platform;
 import javafx.fxml.FXML;
 import javafx.scene.Scene;
 import javafx.scene.canvas.Canvas;
@@ -94,9 +95,11 @@ public class TetrisScreenController extends BaseController {
 
     private Subscriber<TetrisState> updateState() {
         return (state) -> {
-            drawNextBlock(state.nextBlock());
-            setTetrisState(state.tetrisGrid());
-            score.setText(String.valueOf(state.score()));
+            Platform.runLater(() -> {
+                drawNextBlock(state.nextBlock());
+                setTetrisState(state.tetrisGrid());
+                score.setText(String.valueOf(state.score()));
+            });
         };
     }
 

--- a/app/src/main/java/org/se13/view/tetris/TetrisScreenController.java
+++ b/app/src/main/java/org/se13/view/tetris/TetrisScreenController.java
@@ -3,43 +3,29 @@ package org.se13.view.tetris;
 import javafx.fxml.FXML;
 import javafx.scene.Scene;
 import javafx.scene.canvas.Canvas;
+import javafx.scene.canvas.GraphicsContext;
 import javafx.scene.control.Label;
+import javafx.scene.input.KeyEvent;
 import javafx.scene.layout.BorderPane;
+import javafx.scene.paint.Color;
+import javafx.scene.text.Font;
+import org.se13.SE13Application;
+import org.se13.game.block.*;
 import org.se13.game.config.Config;
-import org.se13.game.tetris.DefaultTetrisGame;
+import org.se13.utils.Subscriber;
 import org.se13.view.base.BaseController;
-import org.se13.view.difficulty.LevelSelectScreenController;
+import org.se13.view.nav.AppScreen;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class TetrisScreenController extends BaseController {
-    @Override
-    public void onCreate() {
-        if (Config.SCREEN_WIDTH == 300) {
-            gameSize = DefaultTetrisGame.GameSize.SMALL;
-        } else if (Config.SCREEN_WIDTH == 600) {
-            gameSize = DefaultTetrisGame.GameSize.MEDIUM;
-        } else if (Config.SCREEN_WIDTH == 1920) {
-            gameSize = DefaultTetrisGame.GameSize.LARGE;
-        }
 
-        this.tetrisGame = DefaultTetrisGame.getInstance(gameCanvas, nextBlockCanvas, score, LevelSelectScreenController.gameLevel, LevelSelectScreenController.gameMode, gameSize,false);
-        this.frame.setStyle("-fx-border-color: red;");
+    private static final Logger log = LoggerFactory.getLogger(TetrisScreenController.class);
 
-        Scene scene = gameCanvas.getScene();
-
-        scene.setOnKeyPressed((keyEvent -> {
-            String keyName = keyEvent.getCode().getName();
-
-            if (keyName.compareToIgnoreCase(Config.PAUSE) == 0) {
-                this.tetrisGame.togglePauseState();
-            } else if (keyName.compareToIgnoreCase(Config.EXIT) == 0) {
-                System.exit(0);
-            }
-        }));
-    }
-
-    @Override
-    public void onStart() {
-        this.tetrisGame.startGame();
+    public enum GameSize {
+        SMALL,
+        MEDIUM,
+        LARGE
     }
 
     @FXML
@@ -51,6 +37,191 @@ public class TetrisScreenController extends BaseController {
     @FXML
     private Canvas gameCanvas;
 
-    private DefaultTetrisGame tetrisGame;
-    private DefaultTetrisGame.GameSize gameSize;
+    private TetrisScreenViewModel viewModel;
+    private TetrisActionRepository actionRepository;
+    private TetrisStateRepository stateRepository;
+    private GraphicsContext tetrisGridView;
+    private GraphicsContext nextBlockView;
+
+    private GameSize gameSize;
+    private double width;
+    private double height;
+    private int interval;
+
+    private final char DEFAULT_BLOCK_TEXT = '0';
+    private final char FEVER_BLOCK_TEXT = 'F';
+    private final char WEIGHT_ITEM_BLOCK_TEXT = 'W';
+    private final char RESET_BLOCK_TEXT = 'A';
+    private final char ALL_CLEAR_BLOCK_TEXT = 'A';
+    private final char LINE_CLEAR_BLOCK_TEXT = 'L';
+
+    @Override
+    public void onCreate() {
+        Scene scene = gameCanvas.getScene();
+        viewModel = new TetrisScreenViewModel(actionRepository, stateRepository);
+        tetrisGridView = gameCanvas.getGraphicsContext2D();
+        nextBlockView = nextBlockCanvas.getGraphicsContext2D();
+
+        setInitState();
+
+        viewModel.observe(updateState(), bindGameEnd());
+
+        scene.addEventHandler(KeyEvent.KEY_PRESSED, (key) -> {
+            String keyCode = key.getCode().getName().toLowerCase();
+            handleKeyEvent(keyCode);
+        });
+
+        this.frame.setStyle("-fx-border-color: red;");
+
+        viewModel.connect();
+    }
+
+    public void setArguments(TetrisActionRepository actionRepository, TetrisStateRepository stateRepository) {
+        this.actionRepository = actionRepository;
+        this.stateRepository = stateRepository;
+    }
+
+    private void setInitState() {
+        if (Config.SCREEN_WIDTH == 300) setSmallScreen();
+        else if (Config.SCREEN_WIDTH == 600) setMediumScreen();
+        else if (Config.SCREEN_WIDTH == 1920) setLargeScreen();
+
+        frame.setMaxWidth(width);
+        frame.setMaxHeight(height);
+        gameCanvas.setWidth(width);
+        gameCanvas.setHeight(height);
+    }
+
+    private Subscriber<TetrisState> updateState() {
+        return (state) -> {
+            drawNextBlock(state.nextBlock());
+            setTetrisState(state.tetrisGrid());
+            score.setText(String.valueOf(state.score()));
+        };
+    }
+
+    private Subscriber<TetrisGameEndData> bindGameEnd() {
+        return (endData) -> {
+            SE13Application.navController.navigate(AppScreen.GAMEOVER, (GameOverScreenController controller) -> {
+                controller.setArguments(endData);
+            });
+        };
+    }
+
+    private void setSmallScreen() {
+        gameSize = GameSize.SMALL;
+        width = 100;
+        height = 210;
+        interval = 10;
+    }
+
+    private void setMediumScreen() {
+        gameSize = GameSize.MEDIUM;
+        width = 150;
+        height = 315;
+        interval = 15;
+        tetrisGridView.setFont(new Font("Arial", 20));
+        nextBlockView.setFont(new Font("Arial", 20));
+        nextBlockCanvas.setWidth(100);
+    }
+
+    private void setLargeScreen() {
+        gameSize = GameSize.LARGE;
+        width = 250;
+        height = 530;
+        interval = 25;
+        tetrisGridView.setFont(new Font("Arial", 30));
+        nextBlockView.setFont(new Font("Arial", 30));
+        nextBlockCanvas.setWidth(100);
+    }
+
+    private void setTetrisState(CellID[][] cells) {
+        tetrisGridView.setFill(new Color(0, 0, 0, 1.0));
+        tetrisGridView.fillRect(0, 0, width, height);
+        tetrisGridView.clearRect(0, 0, width, height);
+
+        for (int i = 0; i < cells.length; i++) {
+            for (int j = 0; j < cells[i].length; j++) {
+                CellID cellID = cells[i][j];
+                tetrisGridView.setFill(getCellColor(cellID));
+                tetrisGridView.fillText(String.valueOf(getCellCharacter(cellID)), j * interval, i * interval);
+            }
+        }
+    }
+
+    private void drawNextBlock(CurrentBlock block) {
+        nextBlockView.clearRect(0, 0, width, height);
+
+        BlockPosition[] nextBlockPositions = block.shape();
+
+        int colIndex, rowIndex;
+        Cell[] cells = block.cells();
+
+        for (int i = 0; i < 4; i++) {
+            colIndex = nextBlockPositions[i].getColIndex();
+            rowIndex = nextBlockPositions[i].getRowIndex() + 1;
+
+            nextBlockView.setFill(block.getColor());
+            nextBlockView.setFill(getCellColor(cells[i].cellID()));
+            nextBlockView.fillText(String.valueOf(getCellCharacter(cells[i].cellID())), colIndex * interval, rowIndex * interval);
+        }
+    }
+
+    private Color getCellColor(CellID cellID) {
+        return switch (cellID) {
+            case EMPTY -> null;
+            case IBLOCK_ID -> Block.IBlock.blockColor;
+            case JBLOCK_ID -> Block.JBlock.blockColor;
+            case LBLOCK_ID -> Block.LBlock.blockColor;
+            case OBLOCK_ID -> Block.OBlock.blockColor;
+            case SBLOCK_ID -> Block.SBlock.blockColor;
+            case TBLOCK_ID -> Block.TBlock.blockColor;
+            case ZBLOCK_ID -> Block.ZBlock.blockColor;
+            case CBLOCK_ID,
+                 WEIGHT_ITEM_ID,
+                 FEVER_ITEM_ID,
+                 WEIGHT_BLOCK_ID,
+                 RESET_ITEM_ID,
+                 LINE_CLEAR_ITEM_ID,
+                 ALL_CLEAR_ITEM_ID -> Color.WHITE;
+        };
+    }
+
+    private char getCellCharacter(CellID cellID) {
+        return switch (cellID) {
+            case EMPTY -> ' ';
+            case FEVER_ITEM_ID -> FEVER_BLOCK_TEXT;
+            case WEIGHT_ITEM_ID, WEIGHT_BLOCK_ID -> WEIGHT_ITEM_BLOCK_TEXT;
+            case RESET_ITEM_ID -> RESET_BLOCK_TEXT;
+            case LINE_CLEAR_ITEM_ID -> LINE_CLEAR_BLOCK_TEXT;
+            case ALL_CLEAR_ITEM_ID -> ALL_CLEAR_BLOCK_TEXT;
+            case IBLOCK_ID,
+                 JBLOCK_ID,
+                 LBLOCK_ID,
+                 OBLOCK_ID,
+                 SBLOCK_ID,
+                 TBLOCK_ID,
+                 ZBLOCK_ID,
+                 CBLOCK_ID -> DEFAULT_BLOCK_TEXT;
+        };
+    }
+
+    private void handleKeyEvent(String keyCode) {
+        if (keyCode.compareToIgnoreCase(Config.DROP) == 0) {
+            viewModel.immediateBlockPlace();
+        } else if (keyCode.compareToIgnoreCase(Config.DOWN) == 0) {
+            viewModel.moveBlockDown();
+        } else if (keyCode.compareToIgnoreCase(Config.LEFT) == 0) {
+            viewModel.moveBlockLeft();
+        } else if (keyCode.compareToIgnoreCase(Config.RIGHT) == 0) {
+            viewModel.moveBlockRight();
+        } else if (keyCode.compareToIgnoreCase(Config.CW_SPIN) == 0) {
+            viewModel.rotateBlockCW();
+        } else if (keyCode.compareToIgnoreCase(Config.PAUSE) == 0) {
+            viewModel.togglePauseState();
+        } else if (keyCode.compareToIgnoreCase(Config.EXIT) == 0) {
+            viewModel.exitGame();
+            System.exit(0);
+        }
+    }
 }

--- a/app/src/main/java/org/se13/view/tetris/TetrisScreenViewModel.java
+++ b/app/src/main/java/org/se13/view/tetris/TetrisScreenViewModel.java
@@ -1,0 +1,57 @@
+package org.se13.view.tetris;
+
+import org.se13.utils.Subscriber;
+
+public class TetrisScreenViewModel implements TetrisActionRepository {
+    private TetrisActionRepository actionRepository;
+    private TetrisStateRepository stateRepository;
+
+    public TetrisScreenViewModel(TetrisActionRepository actionRepository, TetrisStateRepository stateRepository) {
+        this.actionRepository = actionRepository;
+        this.stateRepository = stateRepository;
+    }
+
+    public void observe(Subscriber<TetrisState> subscriber, Subscriber<TetrisGameEndData> isGameOver) {
+        stateRepository.subscribe(subscriber, isGameOver);
+    }
+
+    @Override
+    public void connect() {
+        actionRepository.connect();
+    }
+
+    @Override
+    public void immediateBlockPlace() {
+        actionRepository.immediateBlockPlace();
+    }
+
+    @Override
+    public void moveBlockDown() {
+        actionRepository.moveBlockDown();
+    }
+
+    @Override
+    public void moveBlockLeft() {
+        actionRepository.moveBlockLeft();
+    }
+
+    @Override
+    public void moveBlockRight() {
+        actionRepository.moveBlockRight();
+    }
+
+    @Override
+    public void rotateBlockCW() {
+        actionRepository.rotateBlockCW();
+    }
+
+    @Override
+    public void togglePauseState() {
+        actionRepository.togglePauseState();
+    }
+
+    @Override
+    public void exitGame() {
+        actionRepository.exitGame();
+    }
+}

--- a/app/src/main/java/org/se13/view/tetris/TetrisState.java
+++ b/app/src/main/java/org/se13/view/tetris/TetrisState.java
@@ -1,0 +1,7 @@
+package org.se13.view.tetris;
+
+import org.se13.game.block.CellID;
+import org.se13.game.block.CurrentBlock;
+
+public record TetrisState(CellID[][] tetrisGrid, CurrentBlock nextBlock, int score) {
+}

--- a/app/src/main/java/org/se13/view/tetris/TetrisStateRepository.java
+++ b/app/src/main/java/org/se13/view/tetris/TetrisStateRepository.java
@@ -1,0 +1,12 @@
+package org.se13.view.tetris;
+
+import org.se13.utils.Subscriber;
+
+public interface TetrisStateRepository {
+
+    public void gameOver(TetrisGameEndData endData);
+
+    public void response(TetrisState state);
+
+    public void subscribe(Subscriber<TetrisState> subscriber, Subscriber<TetrisGameEndData> isGameOver);
+}

--- a/app/src/main/java/org/se13/view/tetris/TetrisStateRepositoryImpl.java
+++ b/app/src/main/java/org/se13/view/tetris/TetrisStateRepositoryImpl.java
@@ -1,0 +1,32 @@
+package org.se13.view.tetris;
+
+import org.se13.utils.Observer;
+import org.se13.utils.Subscriber;
+
+public class TetrisStateRepositoryImpl implements TetrisStateRepository {
+
+    private final Observer<TetrisState> observer;
+
+    private final Observer<TetrisGameEndData> isGameOver;
+
+    public TetrisStateRepositoryImpl() {
+        this.observer = new Observer<>();
+        this.isGameOver = new Observer<>();
+    }
+
+    @Override
+    public void response(TetrisState state) {
+        this.observer.setValue(state);
+    }
+
+    @Override
+    public void subscribe(Subscriber<TetrisState> subscriber, Subscriber<TetrisGameEndData> isGameOver) {
+        this.observer.subscribe(subscriber);
+        this.isGameOver.subscribe(isGameOver);
+    }
+
+    @Override
+    public void gameOver(TetrisGameEndData endData) {
+        isGameOver.setValue(endData);
+    }
+}

--- a/app/src/test/java/org/se13/game/input/InputTest.java
+++ b/app/src/test/java/org/se13/game/input/InputTest.java
@@ -1,7 +1,5 @@
 package org.se13.game.input;
 
-import javafx.scene.Group;
-import javafx.scene.Scene;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.se13.game.action.TetrisAction;
@@ -13,9 +11,9 @@ public class InputTest {
     @DisplayName("InputManager 클래스 동작 테스트")
     void inputTest() {
         InputManager inputManager = new InputManager();
-        inputManager.add(TetrisAction.CONNECT);
+        inputManager.add(TetrisAction.START);
         assertTrue(inputManager.peekInput());
-        assertEquals(inputManager.getInput(), TetrisAction.CONNECT);
+        assertEquals(inputManager.getInput(), TetrisAction.START);
 
         inputManager.reset();
 

--- a/app/src/test/java/org/se13/game/input/InputTest.java
+++ b/app/src/test/java/org/se13/game/input/InputTest.java
@@ -4,6 +4,7 @@ import javafx.scene.Group;
 import javafx.scene.Scene;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.se13.game.action.TetrisAction;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -11,14 +12,14 @@ public class InputTest {
     @Test
     @DisplayName("InputManager 클래스 동작 테스트")
     void inputTest() {
-        InputManager inputManager = InputManager.getInstance(null);
+        InputManager inputManager = new InputManager();
+        inputManager.add(TetrisAction.CONNECT);
+        assertTrue(inputManager.peekInput());
+        assertEquals(inputManager.getInput(), TetrisAction.CONNECT);
+
         inputManager.reset();
 
-        InputManager newInputManager = InputManager.getInstance(null);
-
-        assertNotSame(inputManager, newInputManager);
-
-        assertFalse(newInputManager.peekInput());
-
+        assertFalse(inputManager.peekInput());
+        assertNull(inputManager.getInput());
     }
 }

--- a/app/src/test/java/org/se13/game/tetris/TetrisGameTest.java
+++ b/app/src/test/java/org/se13/game/tetris/TetrisGameTest.java
@@ -14,6 +14,8 @@ import org.se13.game.item.*;
 import org.se13.game.rule.GameLevel;
 import org.se13.game.rule.GameMode;
 import org.se13.game.timer.*;
+import org.se13.server.TetrisActionHandler;
+import org.se13.server.TetrisClient;
 import org.se13.server.TetrisServer;
 
 import java.util.Random;
@@ -33,7 +35,12 @@ public class TetrisGameTest {
             }
 
             @Override
-            public void handle(TetrisAction request) {
+            public TetrisActionHandler connect(TetrisClient client) {
+                return null;
+            }
+
+            @Override
+            public void disconnect(TetrisClient client) {
 
             }
         });

--- a/app/src/test/java/org/se13/game/tetris/TetrisGameTest.java
+++ b/app/src/test/java/org/se13/game/tetris/TetrisGameTest.java
@@ -1,11 +1,12 @@
 package org.se13.game.tetris;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.se13.SE13Application;
+import org.se13.game.action.TetrisAction;
 import org.se13.game.block.Block;
-import org.se13.game.block.BlockPosition;
 import org.se13.game.block.CellID;
 import org.se13.game.block.CurrentBlock;
 import org.se13.game.grid.TetrisGrid;
@@ -13,12 +14,31 @@ import org.se13.game.item.*;
 import org.se13.game.rule.GameLevel;
 import org.se13.game.rule.GameMode;
 import org.se13.game.timer.*;
+import org.se13.server.TetrisServer;
 
 import java.util.Random;
 
 import static org.junit.jupiter.api.Assertions.*;
 
 public class TetrisGameTest {
+
+    DefaultTetrisGame defaultTetrisGame;
+
+    @BeforeEach
+    void before() {
+        defaultTetrisGame = new DefaultTetrisGame(GameLevel.NORMAL, GameMode.ITEM, new TetrisServer() {
+            @Override
+            public void responseGameOver(int score, boolean isItemMode, String difficulty) {
+
+            }
+
+            @Override
+            public void handle(TetrisAction request) {
+
+            }
+        });
+    }
+
     @Test
     @DisplayName("테트리스 블록 이동 테스트")
     void blockMoveTest() {
@@ -231,82 +251,72 @@ public class TetrisGameTest {
     @Test
     @DisplayName("전반적인 테트리스 게임 테스트")
     void tetrisGameTest() {
-        DefaultTetrisGame defaultTetrisGame = DefaultTetrisGame.getInstance(null, null, null, GameLevel.NORMAL, GameMode.DEFAULT, DefaultTetrisGame.GameSize.MEDIUM,true);
+        assertEquals(0, defaultTetrisGame.getScore());
+        assertEquals("Normal", defaultTetrisGame.getDifficulty());
+        assertTrue(defaultTetrisGame.isItemMode());
 
-        defaultTetrisGame.startGame();
-        defaultTetrisGame.stopGame();
-        assertFalse(defaultTetrisGame.isGameOver());
-        defaultTetrisGame.resetGame();
-
-        DefaultTetrisGame resetedTetrisGame = DefaultTetrisGame.getInstance(null, null, null, GameLevel.NORMAL, GameMode.DEFAULT, DefaultTetrisGame.GameSize.MEDIUM,true);
-
-        assertNotSame(defaultTetrisGame, resetedTetrisGame);
-        assertEquals(0, resetedTetrisGame.getScore());
-        assertEquals("Normal", resetedTetrisGame.getDifficulty());
-        assertFalse(resetedTetrisGame.isItemMode());
-
-        CurrentBlock currentBlock = resetedTetrisGame.getCurrentBlock();
+        CurrentBlock currentBlock = defaultTetrisGame.getCurrentBlock();
 
         assertNotNull(currentBlock);
 
-        resetedTetrisGame.setCurrentBlock(new CurrentBlock(Block.IBlock)); // (0, 3)
+        defaultTetrisGame.setCurrentBlock(new CurrentBlock(Block.IBlock)); // (0, 3)
 
-        resetedTetrisGame.moveBlockDown(); // (1, 3)
-        resetedTetrisGame.moveBlockDown(); // (2, 3)
-        resetedTetrisGame.moveBlockDown(); // (3, 3)
-        resetedTetrisGame.moveBlockLeft(); // (3, 2)
-        resetedTetrisGame.moveBlockRight(); // (3, 3)
+        defaultTetrisGame.moveBlockDown(); // (1, 3)
+        defaultTetrisGame.moveBlockDown(); // (2, 3)
+        defaultTetrisGame.moveBlockDown(); // (3, 3)
+        defaultTetrisGame.moveBlockLeft(); // (3, 2)
+        defaultTetrisGame.moveBlockRight(); // (3, 3)
 
-        resetedTetrisGame.rotateBlockCW();
+        defaultTetrisGame.rotateBlockCW();
 
-        resetedTetrisGame.drawBlockIntoGrid();
+        defaultTetrisGame.drawBlockIntoGrid();
 
-        TetrisGrid tetrisGrid = resetedTetrisGame.getTetrisGrid();
+        TetrisGrid tetrisGrid = defaultTetrisGame.getTetrisGrid();
         assertEquals(CellID.IBLOCK_ID, tetrisGrid.getCell(3, 5));
         assertEquals(CellID.IBLOCK_ID, tetrisGrid.getCell(4, 5));
         assertEquals(CellID.IBLOCK_ID, tetrisGrid.getCell(5, 5));
         assertEquals(CellID.IBLOCK_ID, tetrisGrid.getCell(6, 5));
-        resetedTetrisGame.deleteCurrentBlockFromGrid();
+        defaultTetrisGame.deleteCurrentBlockFromGrid();
 
-        resetedTetrisGame.processUserInput("a");
-        resetedTetrisGame.drawBlockIntoGrid();
+        defaultTetrisGame.processUserInput(TetrisAction.MOVE_BLOCK_LEFT);
+        defaultTetrisGame.drawBlockIntoGrid();
         assertEquals(CellID.IBLOCK_ID, tetrisGrid.getCell(3, 4));
         assertEquals(CellID.IBLOCK_ID, tetrisGrid.getCell(4, 4));
         assertEquals(CellID.IBLOCK_ID, tetrisGrid.getCell(5, 4));
         assertEquals(CellID.IBLOCK_ID, tetrisGrid.getCell(6, 4));
 
-        resetedTetrisGame.deleteCurrentBlockFromGrid();
+        defaultTetrisGame.deleteCurrentBlockFromGrid();
         assertEquals(CellID.EMPTY, tetrisGrid.getCell(3, 4));
         assertEquals(CellID.EMPTY, tetrisGrid.getCell(4, 4));
         assertEquals(CellID.EMPTY, tetrisGrid.getCell(5, 4));
         assertEquals(CellID.EMPTY, tetrisGrid.getCell(6, 4));
 
-        resetedTetrisGame.immediateBlockPlace();
-        resetedTetrisGame.drawBlockIntoGrid();
+        defaultTetrisGame.immediateBlockPlace();
+        defaultTetrisGame.drawBlockIntoGrid();
         assertEquals(CellID.IBLOCK_ID, tetrisGrid.getCell(18, 4));
         assertEquals(CellID.IBLOCK_ID, tetrisGrid.getCell(19, 4));
         assertEquals(CellID.IBLOCK_ID, tetrisGrid.getCell(20, 4));
         assertEquals(CellID.IBLOCK_ID, tetrisGrid.getCell(21, 4));
 
-        resetedTetrisGame.deleteCurrentBlockFromGrid();
+        defaultTetrisGame.deleteCurrentBlockFromGrid();
 
         for (int i = 0; i < 9; i++) {
             tetrisGrid.setCell(0, i, CellID.IBLOCK_ID);
             tetrisGrid.setCell(1, i, CellID.IBLOCK_ID);
         }
 
-        assertTrue(resetedTetrisGame.isGameOver());
+        assertTrue(defaultTetrisGame.isGameOver());
 
         for (int i = 0; i < 9; i++) {
             tetrisGrid.setCell(0, i, CellID.EMPTY);
             tetrisGrid.setCell(1, i, CellID.EMPTY);
         }
 
-        resetedTetrisGame.startGame();
-        resetedTetrisGame.togglePauseState();
-        assertTrue(resetedTetrisGame.isGamePaused());
+        defaultTetrisGame.startGame();
+        defaultTetrisGame.togglePauseState();
+        assertTrue(defaultTetrisGame.isGamePaused());
 
-        resetedTetrisGame.togglePauseState();
+        defaultTetrisGame.togglePauseState();
 
         for (int i = 0; i < 10; i++) {
             tetrisGrid.setCell(10, i, CellID.IBLOCK_ID);
@@ -323,31 +333,31 @@ public class TetrisGameTest {
         }
 
 
-        resetedTetrisGame.setBlockPlaced(true);
-        resetedTetrisGame.pulse(System.nanoTime());
-        resetedTetrisGame.update();
-        assertEquals(DefaultTetrisGame.BlockSpeed.DEFAULT, resetedTetrisGame.getBlockSpeed());
+        defaultTetrisGame.setBlockPlaced(true);
+        defaultTetrisGame.pulse(System.nanoTime());
+        defaultTetrisGame.update();
+        assertEquals(DefaultTetrisGame.BlockSpeed.DEFAULT, defaultTetrisGame.getBlockSpeed());
 
-        while (resetedTetrisGame.isAnimationTimerEnded() == true) {
-            resetedTetrisGame.update();
+        while (defaultTetrisGame.isAnimationTimerEnded() == true) {
+            defaultTetrisGame.update();
         }
 
-        resetedTetrisGame.update();
+        defaultTetrisGame.update();
 
-        resetedTetrisGame.setClearedLines(11);
-        resetedTetrisGame.updateBlockSpeed();
+        defaultTetrisGame.setClearedLines(11);
+        defaultTetrisGame.updateBlockSpeed();
 
-        assertEquals(DefaultTetrisGame.BlockSpeed.FASTER, resetedTetrisGame.getBlockSpeed());
+        assertEquals(DefaultTetrisGame.BlockSpeed.FASTER, defaultTetrisGame.getBlockSpeed());
 
-        resetedTetrisGame.setClearedLines(31);
-        resetedTetrisGame.updateBlockSpeed();
+        defaultTetrisGame.setClearedLines(31);
+        defaultTetrisGame.updateBlockSpeed();
 
-        assertEquals(DefaultTetrisGame.BlockSpeed.RAGE, resetedTetrisGame.getBlockSpeed());
+        assertEquals(DefaultTetrisGame.BlockSpeed.RAGE, defaultTetrisGame.getBlockSpeed());
 
-        resetedTetrisGame.setClearedLines(101);
-        resetedTetrisGame.updateBlockSpeed();
+        defaultTetrisGame.setClearedLines(101);
+        defaultTetrisGame.updateBlockSpeed();
 
-        assertEquals(DefaultTetrisGame.BlockSpeed.IMPOSSIBLE, resetedTetrisGame.getBlockSpeed());
+        assertEquals(DefaultTetrisGame.BlockSpeed.IMPOSSIBLE, defaultTetrisGame.getBlockSpeed());
     }
 
     @Test
@@ -387,23 +397,8 @@ public class TetrisGameTest {
     }
 
     @Test
-    @DisplayName("메모리릭_테스트")
-    void memoryLeakTest() {
-        DefaultTetrisGame game1 = DefaultTetrisGame.getInstance(null, null, null, GameLevel.NORMAL, GameMode.DEFAULT, DefaultTetrisGame.GameSize.MEDIUM, true);
-        DefaultTetrisGame game2 = DefaultTetrisGame.getInstance(null, null, null, GameLevel.NORMAL, GameMode.DEFAULT, DefaultTetrisGame.GameSize.MEDIUM, true);
-
-        assertEquals(game1, game2);
-
-        game1.resetGame();
-        DefaultTetrisGame game3 = DefaultTetrisGame.getInstance(null, null, null, GameLevel.NORMAL, GameMode.DEFAULT, DefaultTetrisGame.GameSize.MEDIUM, true);
-
-        assertNotEquals(game1, game3);
-    }
-
-    @Test
     @DisplayName("피버_모드_아이템_발동_테스트")
     void feverItemTest() throws InterruptedException {
-        DefaultTetrisGame defaultTetrisGame = DefaultTetrisGame.getInstance(null, null, null, GameLevel.NORMAL, GameMode.DEFAULT, DefaultTetrisGame.GameSize.MEDIUM, true);
         FeverModeTimer.DEFAULT_DURATION = 500000000L;
 
         defaultTetrisGame.startGame();
@@ -433,8 +428,6 @@ public class TetrisGameTest {
     @Test
     @DisplayName("속도_리셋_아이템_발동_테스트")
     void resetSpeedItemTest() {
-        DefaultTetrisGame defaultTetrisGame = DefaultTetrisGame.getInstance(null, null, null, GameLevel.NORMAL, GameMode.DEFAULT, DefaultTetrisGame.GameSize.MEDIUM, true);
-
         defaultTetrisGame.startGame();
         defaultTetrisGame.pulse(System.nanoTime());
 
@@ -458,9 +451,6 @@ public class TetrisGameTest {
     @Test
     @DisplayName("보드_리셋_아이템_발동_테스트")
     void resetBoardItemTest() {
-        DefaultTetrisGame defaultTetrisGame = DefaultTetrisGame.getInstance(null, null, null, GameLevel.NORMAL, GameMode.DEFAULT, DefaultTetrisGame.GameSize.MEDIUM, true);
-        BlockPosition nothing = new BlockPosition(0, 0);
-
         defaultTetrisGame.startGame();
         defaultTetrisGame.pulse(System.nanoTime());
 
@@ -486,10 +476,6 @@ public class TetrisGameTest {
     @Test
     @DisplayName("아이템이_잘_생성되는지_테스트")
     void createItemBlockTest() {
-        DefaultTetrisGame defaultTetrisGame = DefaultTetrisGame.getInstance(null, null, null, GameLevel.NORMAL, GameMode.ITEM, DefaultTetrisGame.GameSize.MEDIUM, true);
-        defaultTetrisGame.resetGame();
-        defaultTetrisGame = DefaultTetrisGame.getInstance(null, null, null, GameLevel.NORMAL, GameMode.ITEM, DefaultTetrisGame.GameSize.MEDIUM, true);
-
         for (int i = 0; i < 100; i++) {
             CurrentBlock block = defaultTetrisGame.nextItemBlock();
             assertInstanceOf(TetrisItem.class, block.getItem());

--- a/app/src/test/java/org/se13/server/LocalTetrisServerTest.java
+++ b/app/src/test/java/org/se13/server/LocalTetrisServerTest.java
@@ -35,7 +35,7 @@ class LocalTetrisServerTest {
                 endDataTest = endData;
             }
         };
-        client = new TetrisClient(repository);
+        client = new TetrisClient(-1, repository);
         server = new LocalTetrisServer(GameLevel.EASY, GameMode.ITEM);
         handler = server.connect(client);
     }
@@ -56,7 +56,7 @@ class LocalTetrisServerTest {
                 endDataTest = endData;
             }
         };
-        client = new TetrisClient(repository);
+        client = new TetrisClient(-1, repository);
         server = new LocalTetrisServer(GameLevel.EASY, GameMode.ITEM);
         handler = server.connect(client);
 

--- a/app/src/test/java/org/se13/server/LocalTetrisServerTest.java
+++ b/app/src/test/java/org/se13/server/LocalTetrisServerTest.java
@@ -1,0 +1,68 @@
+package org.se13.server;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.se13.game.action.TetrisAction;
+import org.se13.game.rule.GameLevel;
+import org.se13.game.rule.GameMode;
+import org.se13.view.tetris.TetrisGameEndData;
+import org.se13.view.tetris.TetrisState;
+import org.se13.view.tetris.TetrisStateRepository;
+import org.se13.view.tetris.TetrisStateRepositoryImpl;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class LocalTetrisServerTest {
+
+    TetrisStateRepository repository;
+    TetrisClient client;
+    LocalTetrisServer server;
+
+    TetrisState stateTest;
+    TetrisGameEndData endDataTest;
+
+    @BeforeEach
+    void setUp() {
+        repository = new TetrisStateRepositoryImpl() {
+            @Override
+            public void response(TetrisState state) {
+                stateTest = state;
+            }
+
+            @Override
+            public void gameOver(TetrisGameEndData endData) {
+                endDataTest = endData;
+            }
+        };
+        client = new TetrisClient(repository);
+        server = new LocalTetrisServer(GameLevel.EASY, GameMode.ITEM, client);
+    }
+
+    @Test
+    void baseTest() {
+        server.handle(TetrisAction.CONNECT);
+        server.handle(TetrisAction.TOGGLE_PAUSE_STATE);
+        server.handle(TetrisAction.TOGGLE_PAUSE_STATE);
+        server.handle(TetrisAction.MOVE_BLOCK_LEFT);
+        server.handle(TetrisAction.MOVE_BLOCK_RIGHT);
+        server.handle(TetrisAction.ROTATE_BLOCK_CW);
+        server.handle(TetrisAction.EXIT_GAME);
+
+        assertNotNull(stateTest);
+    }
+
+    @Test
+    void gameOverTest() {
+        server = new LocalTetrisServer(GameLevel.EASY, GameMode.ITEM, client);
+        server.handle(TetrisAction.EXIT_GAME);
+        assertEquals("Easy", endDataTest.difficulty());
+
+        server = new LocalTetrisServer(GameLevel.NORMAL, GameMode.ITEM, client);
+        server.handle(TetrisAction.EXIT_GAME);
+        assertEquals("Normal", endDataTest.difficulty());
+
+        server = new LocalTetrisServer(GameLevel.HARD, GameMode.ITEM, client);
+        server.handle(TetrisAction.EXIT_GAME);
+        assertEquals("Hard", endDataTest.difficulty());
+    }
+}


### PR DESCRIPTION
현재 구조는 테트리스 로직과 JavaFX UI가 혼합되어 있습니다.
이 구조로는 대전 모드를 개발하기 어렵기 때문에 아래 구조로 리팩토링 했습니다.

기존 로직과 달라진 중요한 변경점으로는
1. DefaultTetrisGame 은 더 이상 싱글톤이 아닙니다.
2. DefaultTetrisGame 에 존재하는 JavaFX 의존성을 모두 제거했고, 이제 쉽게 테스트 가능하므로 isTestMode 변수를 삭제했습니다. 
3. AnimationTimer에서 java.util.Timer로 변경했습니다. 그리고 pulse 의 주체를 TetrisServer로 옮겼습니다.
4. JavaFX 의존성을 제거하기 위해 MVVM 아키텍처를 일부 적용했습니다. (Observer랑 Subscriber 참고)

![d2](https://github.com/binlee0903/se13_team_project/assets/69467411/f323b001-1d6e-4ca2-bbcc-e5f24ab2b169)

[대전 모드 예시]
1. TetrisServer를 상속받는 LocalBattleTetrisServer 를 추가하기
5. LocalBattleTetrisServer는 2명의 플레이어를 연결받을 수 있음.

[온라인 모드 예시]
1. TetrisActionRepository와 TetrisActionHandler, TetrisStateRepository에 네트워크 연결, 직렬화, 송/수신 코드 추가
2. TetrisServer를 상속받는 OnlineTetrisServer를 추가하기
6. 네트워크 지연시간이 문제가 될 경우 OnlineTetrisServer와 TetrisStateRepository에 턴 타이머 도입

[컴퓨터 대전 예시
1. TetrisScreenController에서 컴퓨터가 가짜 UserInput을 생성할 수 있도록 수정
2. 나머지 코드는 대전 모드와 동일
