### PR TITLE
feat: handleServerError 구현

### DIFF
--- a/app/src/main/java/org/se13/view/tetris/BattleScreenController.java
+++ b/app/src/main/java/org/se13/view/tetris/BattleScreenController.java
@@ -5,6 +5,7 @@ import javafx.fxml.FXML;
 import javafx.scene.Scene;
 import javafx.scene.canvas.Canvas;
 import javafx.scene.canvas.GraphicsContext;
+import javafx.scene.control.Alert;
 import javafx.scene.control.Label;
 import javafx.scene.input.KeyEvent;
 import javafx.scene.layout.BorderPane;
@@ -120,7 +121,17 @@ public class BattleScreenController extends BaseController {
     }
 
     private void handleServerError(ServerErrorEvent error) {
-        // TODO: 서버 에러 메시지를 보여주는 기능
+        // 서버 에러 메시지를 보여주고 시작 화면으로 이동
+        log.error("Server Error: {}", error.message());
+        Platform.runLater(() -> {
+            Alert alert = new Alert(Alert.AlertType.ERROR);
+            alert.setTitle("Server Error");
+            alert.setHeaderText("A server error has occurred");
+            alert.setContentText(error.message() + "\n" + "게임 시작 화면으로 이동합니다.");
+            alert.showAndWait();
+            // 오류창을 닫으면 시작 화면으로 이동
+            SE13Application.navController.navigate(AppScreen.START);
+        });
     }
 
     private void handleUpdateState(UpdateTetrisState state) {

--- a/app/src/main/java/org/se13/view/tetris/TetrisScreenController.java
+++ b/app/src/main/java/org/se13/view/tetris/TetrisScreenController.java
@@ -5,6 +5,7 @@ import javafx.fxml.FXML;
 import javafx.scene.Scene;
 import javafx.scene.canvas.Canvas;
 import javafx.scene.canvas.GraphicsContext;
+import javafx.scene.control.Alert;
 import javafx.scene.control.Label;
 import javafx.scene.input.KeyEvent;
 import javafx.scene.layout.BorderPane;
@@ -114,7 +115,17 @@ public class TetrisScreenController extends BaseController {
     }
 
     private void handleServerError(ServerErrorEvent error) {
-        // TODO: 서버 에러 메시지를 보여주는 기능
+        // 서버 에러 메시지를 보여주고 시작 화면으로 이동
+        log.error("Server Error: {}", error.message());
+        Platform.runLater(() -> {
+            Alert alert = new Alert(Alert.AlertType.ERROR);
+            alert.setTitle("Server Error");
+            alert.setHeaderText("A server error has occurred");
+            alert.setContentText(error.message() + "\n" + "게임 시작 화면으로 이동합니다.");
+            alert.showAndWait();
+            // 오류창을 닫으면 시작 화면으로 이동
+            SE13Application.navController.navigate(AppScreen.START);
+        });
     }
 
     private void handleUpdateState(UpdateTetrisState state) {


### PR DESCRIPTION
- 먼저 log로 에러 메시지를 띄움.
- Platform.runLater를 이용함.
- Alert창을 팝업으로 띄워 에러 메시지를 보여줌.
- 확인을 누르면 시작화면으로 이동

```java
// BattleScreenController.java
// TetrisScreenController.java
// 모두 동일
    private void handleServerError(ServerErrorEvent error) {
        // 서버 에러 메시지를 보여주고 시작 화면으로 이동
        log.error("Server Error: {}", error.message());
        Platform.runLater(() -> {
            Alert alert = new Alert(Alert.AlertType.ERROR);
            alert.setTitle("Server Error");
            alert.setHeaderText("A server error has occurred");
            alert.setContentText(error.message() + "\n" + "게임 시작 화면으로 이동합니다.");
            alert.showAndWait();
            // 오류창을 닫으면 시작 화면으로 이동
            SE13Application.navController.navigate(AppScreen.START);
        });
    }
```